### PR TITLE
Fix undefined variable $orders

### DIFF
--- a/app/Http/Controllers/Admin/CollectionController.php
+++ b/app/Http/Controllers/Admin/CollectionController.php
@@ -47,8 +47,15 @@ class CollectionController extends Controller
         $collectedAmount = Collection::where('status', 'collected')->sum('amount');
         $pendingAmount = Collection::where('status', 'pending')->sum('amount');
 
+        // الحصول على الطلبات للعرض في الصفحة
+        $orders = collect();
+        if ($collections->isNotEmpty()) {
+            $orders = $collections->pluck('order')->filter();
+        }
+
         return view('admin.collections.index', compact(
             'collections',
+            'orders',
             'totalCollections',
             'pendingCollections',
             'collectedAmount',

--- a/app/Http/Controllers/Admin/UserController.php
+++ b/app/Http/Controllers/Admin/UserController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers\Admin;
 use App\Http\Controllers\Controller;
 use Illuminate\Http\Request;
 use App\Models\User;
+use App\Models\Order;
 use Spatie\Permission\Models\Role;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Validation\Rules;
@@ -113,7 +114,17 @@ class UserController extends Controller
         // الحصول على صلاحيات المستخدم
         $permissions = $user->getAllPermissions()->pluck('name');
         
-        return view('admin.users.show', compact('user', 'permissions'));
+        // الحصول على طلبات المستخدم إذا كان عميل
+        $orders = collect();
+        if ($user->hasRole('customer')) {
+            $orders = Order::where('customer_id', $user->id)
+                ->with(['items.product'])
+                ->latest()
+                ->take(10)
+                ->get();
+        }
+        
+        return view('admin.users.show', compact('user', 'permissions', 'orders'));
     }
 
     /**


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Resolve 'Undefined variable $orders' error in admin user and collection views.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The `$orders` variable was being accessed in `admin/users/show.blade.php` and `admin/collections/index.blade.php` views, but was not being passed from their respective controller methods (`Admin\UserController@show` and `Admin\CollectionController@index`). This PR adds the logic to retrieve and pass the `$orders` data to these views, ensuring the variable is defined.

---

[Open in Web](https://cursor.com/agents?id=bc-34944b17-940a-4f18-a910-5da6156382f4) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-34944b17-940a-4f18-a910-5da6156382f4) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)