### PR TITLE
Fix missing admin app layout view

### DIFF
--- a/resources/views/admin/collections/index.blade.php
+++ b/resources/views/admin/collections/index.blade.php
@@ -1,4 +1,4 @@
-@extends('admin.layouts.app')
+@extends('layouts.admin')
 
 @section('title', 'تقرير التحصيلات')
 


### PR DESCRIPTION
Update `resources/views/admin/collections/index.blade.php` to use `layouts.admin` to resolve "View [admin.layouts.app] not found" error.

---

[Open in Web](https://cursor.com/agents?id=bc-0f9ea147-35b0-453e-b108-eb6821918cbe) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-0f9ea147-35b0-453e-b108-eb6821918cbe) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)