### PR TITLE
Fix missing total method on collection

### DIFF
--- a/app/Http/Controllers/Admin/CollectionController.php
+++ b/app/Http/Controllers/Admin/CollectionController.php
@@ -48,15 +48,13 @@ class CollectionController extends Controller
         $pendingAmount = Collection::where('status', 'pending')->sum('amount');
 
 
-        $orders = collect();
-        if ($collections->isNotEmpty()) {
-            $orders = $collections->pluck('order_id')->unique();
-        }
+        // Count unique orders with collections
+        $ordersCount = Collection::distinct('order_id')->count('order_id');
 
         return view('admin.collections.index', compact(
             'collections',
             'totalCollections',
-            'orders',
+            'ordersCount',
             'pendingCollections',
             'collectedAmount',
             'pendingAmount'

--- a/app/Http/Controllers/Admin/ReportController.php
+++ b/app/Http/Controllers/Admin/ReportController.php
@@ -9,6 +9,7 @@ use App\Models\Product;
 use App\Models\Warehouse;
 use App\Models\ProductStock;
 use App\Models\Order;
+use App\Models\PurchaseOrder;
 use Carbon\Carbon;
 use App\Models\Country;
 
@@ -260,9 +261,9 @@ class ReportController extends Controller
     $totalCollections = $query->sum('total_amount');
 
     // تحميل الطلبات مع بيانات التصفية
-    $orders = $query->orderBy('created_at', 'desc')->paginate(20);
+    $collections = $query->orderBy('created_at', 'desc')->paginate(20);
 
-    return view('reports.collections.index', compact('orders', 'totalCollections'));
+    return view('admin.reports.collections', compact('collections', 'totalCollections'));
 }
     
     /**
@@ -270,6 +271,28 @@ class ReportController extends Controller
      */
     public function purchases(Request $request)
     {
-        return view('admin.reports.purchases');
+        $query = PurchaseOrder::query();
+
+        // فلترة حسب نطاق التاريخ
+        if ($request->filled('date_range')) {
+            $this->applyDateRangeFilter($query, $request->input('date_range'));
+        }
+
+        // فلترة حسب تواريخ بداية ونهاية مخصصة
+        if ($request->filled('start_date')) {
+            $query->where('created_at', '>=', Carbon::parse($request->start_date)->startOfDay());
+        }
+        if ($request->filled('end_date')) {
+            $query->where('created_at', '<=', Carbon::parse($request->end_date)->endOfDay());
+        }
+
+        // فلترة حسب الحالة
+        if ($request->filled('status')) {
+            $query->where('status', $request->status);
+        }
+
+        $purchaseOrders = $query->orderBy('created_at', 'desc')->paginate(20);
+
+        return view('admin.reports.purchases', compact('purchaseOrders'));
     }
 }

--- a/resources/views/admin/collections/index.blade.php
+++ b/resources/views/admin/collections/index.blade.php
@@ -59,13 +59,13 @@
             <div class="card shadow-sm border-0">
                 <div class="card-body text-center">
                     <h5 class="card-title">عدد الطلبات</h5>
-                    <p class="h4">{{ $orders->total() }}</p>
+                    <p class="h4">{{ $ordersCount }}</p>
                 </div>
             </div>
         </div>
     </div>
 
-    @if($orders->isEmpty())
+    @if($collections->isEmpty())
         <div class="alert alert-info text-center">
             لا توجد بيانات مطابقة للفلاتر المحددة.
         </div>


### PR DESCRIPTION
Fixes `total()` method calls on Laravel Collections which caused a 'method does not exist' error.

The `total()` method is only available on Laravel's `LengthAwarePaginator` (returned by `paginate()`), not on base `Collection` instances. This PR addresses several instances where `total()` was incorrectly called on non-paginated collections or where data was not properly passed/paginated to views expecting it.

---

[Open in Web](https://cursor.com/agents?id=bc-77a639fe-f525-4f2e-a0b5-36ea4b5d072f) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-77a639fe-f525-4f2e-a0b5-36ea4b5d072f) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)