### PR TITLE
Fix unknown column order_id in collections

### DIFF
--- a/app/Models/Collection.php
+++ b/app/Models/Collection.php
@@ -98,6 +98,6 @@ class Collection extends Model
      */
     public function order()
     {
-        return $this->shipment->order;
+        return $this->hasOneThrough(Order::class, Shipment::class, 'id', 'id', 'shipment_id', 'order_id');
     }
 }


### PR DESCRIPTION
Refactor Collection model and controller to correctly use `shipment_id` for collections, resolving 'Unknown column `order_id`' errors.

---

[Open in Web](https://cursor.com/agents?id=bc-183e82c5-4254-4ed3-acef-21b9c9b39728) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-183e82c5-4254-4ed3-acef-21b9c9b39728) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)