### PR TITLE
Fix undefined orders count variable

### DIFF
--- a/app/Http/Controllers/Admin/CountryController.php
+++ b/app/Http/Controllers/Admin/CountryController.php
@@ -81,7 +81,7 @@ class CountryController extends Controller
         $addressesCount = $country->addresses()->count();
         
         // عدد الطلبات من هذا البلد
-        $ordersCount = $country->orders()->count();
+        $ordersCount = $country->orders()->count() ?? 0;
         
         // عدد المستودعات في هذا البلد
         $warehousesCount = $country->warehouses()->count();

--- a/app/Http/Controllers/User/AccountController.php
+++ b/app/Http/Controllers/User/AccountController.php
@@ -19,8 +19,12 @@ class AccountController extends Controller
     {
         $user = auth()->user();
         
+        if (!$user) {
+            return redirect()->route('login');
+        }
+        
         // إحصائيات للمستخدم
-        $ordersCount = Order::where('customer_id', $user->id)->count();
+        $ordersCount = Order::where('customer_id', $user->id)->count() ?? 0;
         $addressesCount = Address::where('customer_id', $user->id)->count();
         
         // آخر الطلبات

--- a/resources/views/admin/countries/show.blade.php
+++ b/resources/views/admin/countries/show.blade.php
@@ -104,7 +104,7 @@
                                 <div class="mb-3">
                                     <i class="fas fa-shopping-cart fa-2x text-info"></i>
                                 </div>
-                                <h3 class="mb-1">{{ $ordersCount }}</h3>
+                                <h3 class="mb-1">{{ $ordersCount ?? 0 }}</h3>
                                 <div class="text-muted">{{ __('orders_count') }}</div>
                             </div>
                         </div>

--- a/resources/views/user/account/index.blade.php
+++ b/resources/views/user/account/index.blade.php
@@ -95,7 +95,7 @@
                                     </div>
                                     <div class="mr-4">
                                         <h3 class="font-semibold text-lg">طلباتي</h3>
-                                        <p class="text-gray-600">{{ $ordersCount }} طلب</p>
+                                        <p class="text-gray-600">{{ $ordersCount ?? 0 }} طلب</p>
                                     </div>
                                 </div>
                                 <div class="mt-4">


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Add null coalescing operators and an authentication check to resolve 'Undefined variable $ordersCount' errors.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The `$ordersCount` variable was correctly defined in most cases, but the error indicated specific scenarios where it was undefined. This PR adds defensive programming by providing default values using the null coalescing operator (`?? 0`) in both controllers and Blade templates, and ensures proper authentication for account-related data.

---

[Open in Web](https://cursor.com/agents?id=bc-cd237072-95da-4fa2-bf94-80dde4da112e) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-cd237072-95da-4fa2-bf94-80dde4da112e) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)